### PR TITLE
[TASK] TYPO3 14 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^12.4 || ^13.4",
-    "typo3/cms-form": "^12.4 || ^13.4"
+    "typo3/cms-core": "^12.4 || ^13.4 || ^14.0",
+    "typo3/cms-form": "^12.4 || ^13.4 || ^14.0"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,10 +7,10 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'info@mediatis.de',
     'author_company' => 'Mediatis AG',
     'state' => 'stable',
-    'version' => '4.1.1',
+    'version' => '4.2.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
+            'typo3' => '12.4.0-14.4.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
Bump typo3/cms-core and typo3/cms-form constraints to 12.4-14.4.99 (composer.json + ext_emconf.php). No PHP API changes - ext_localconf.php and Configuration/JavaScriptModules.php are v14-compatible.